### PR TITLE
Adapt for jackrabbit running in tomcat

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -512,6 +512,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
         $curl = $request->execute(true);
         switch ($curl->getHeader('Content-Type')) {
             case 'text/xml; charset=utf-8':
+            case 'text/xml;charset=utf-8':
                 return $this->decodeBinaryDom($curl->getResponse());
             case 'jcr-value/binary;charset=utf-8':
             case 'jcr-value/binary; charset=utf-8':

--- a/src/Jackalope/Transport/Jackrabbit/Request.php
+++ b/src/Jackalope/Transport/Jackrabbit/Request.php
@@ -517,7 +517,7 @@ class Request
         // TODO extract HTTP status string from response, more descriptive about error
 
         // use XML error response if it's there
-        if (substr($response, 0, 1) === '<') {
+        if (substr($response, 0, 2) === '<?') {
             $dom = new DOMDocument();
             $dom->loadXML($response);
             $err = $dom->getElementsByTagNameNS(Client::NS_DCR, 'exception');
@@ -558,7 +558,7 @@ class Request
                 }
             }
         }
-        if (404 === $httpCode) {
+        if (404 == $httpCode) {
             throw new PathNotFoundException("HTTP 404 Path Not Found: {$this->method} \n" . $this->getShortErrorString());
         } elseif (405 == $httpCode) {
             throw new HTTPErrorException("HTTP 405 Method Not Allowed: {$this->method} \n" . $this->getShortErrorString(), 405);


### PR DESCRIPTION
This is basically all that needs to change to make all the tests run with jackrabbit on tomcat 6. Main problem was the error handling: while Jetty's (jackrabbit-standalone) error pages are valid xml Tomcat's are not. But checking the response is only needed when jackrabbit returns an error, which is valid xml starting with <?xml ...

So after changing that check all tests run fine ... 
