### PR TITLE
adjust to transport interface change, for now not optimizing

### DIFF
--- a/tests/Jackalope/Transport/Jackrabbit/ClientTest.php
+++ b/tests/Jackalope/Transport/Jackrabbit/ClientTest.php
@@ -320,66 +320,6 @@ class ClientTest extends JackrabbitTestCase
     }
 
     /**
-     * @covers \Jackalope\Transport\Jackrabbit\Client::getNodePathForIdentifier
-     * @expectedException \PHPCR\RepositoryException
-     */
-    public function testGetNodePathForIdentifierEmptyResponse()
-    {
-        $dom = new DOMDocument();
-        $dom->load(__DIR__.'/../../../fixtures/empty.xml');
-
-        $t = $this->getTransportMock('testuri');
-        $request = $this->getRequestMock($dom, array('setBody'));
-        $t->expects($this->once())
-            ->method('getRequest')
-            ->will($this->returnValue($request));
-        $t->getNodePathForIdentifier('test');
-    }
-
-    /**
-     * @covers \Jackalope\Transport\Jackrabbit\Client::getNodePathForIdentifier
-     * @expectedException \PHPCR\RepositoryException
-     */
-    public function testGetNodePathForIdentifierWrongWorkspace()
-    {
-        $locateRequest = $this->getTransportMock()->buildLocateRequestMock('test');
-        $dom = new DOMDocument();
-        $dom->load(__DIR__.'/../../../fixtures/locateRequest.xml');
-
-        $t = $this->getTransportMock('testuri');
-        $request = $this->getRequestMock($dom, array('setBody'));
-        $t->expects($this->once())
-            ->method('getRequest')
-            ->with(Request::REPORT, 'testWorkspaceUri')
-            ->will($this->returnValue($request));
-        $request->expects($this->once())
-            ->method('setBody')
-            ->with($locateRequest);
-        $t->getNodePathForIdentifier('test');
-    }
-
-    /**
-     * @covers \Jackalope\Transport\Jackrabbit\Client::getNodePathForIdentifier
-     */
-    public function testGetNodePathForIdentifier()
-    {
-        $locateRequest = $this->getTransportMock()->buildLocateRequestMock('test');
-        $dom = new DOMDocument();
-        $dom->load(__DIR__.'/../../../fixtures/locateRequestTests.xml');
-
-        $t = $this->getTransportMock('testuri');
-        $request = $this->getRequestMock($dom, array('setBody'));
-        $t->expects($this->once())
-            ->method('getRequest')
-            ->with(Request::REPORT, 'testWorkspaceUri')
-            ->will($this->returnValue($request));
-        $request->expects($this->once())
-            ->method('setBody')
-            ->with($locateRequest);
-        $this->assertSame('/tests_level1_access_base/idExample', $t->getNodePathForIdentifier('test'));
-    }
-
-    /**
      * @covers \Jackalope\Transport\Jackrabbit\Client::getNamespaces
      * @expectedException \PHPCR\RepositoryException
      */
@@ -394,7 +334,7 @@ class ClientTest extends JackrabbitTestCase
             ->method('getRequest')
             ->will($this->returnValue($request));
 
-        $ns = $t->getNamespaces();
+        $t->getNamespaces();
     }
 
     /**


### PR DESCRIPTION
alternative to #33 so that we can merge https://github.com/jackalope/jackalope/pull/153 now and have something that still works. then once jackrabbit starts supporting id requests, we can update without a BC break mess in jackalope.
