### PR TITLE
Override Jackrabbit's reported SNS support to false

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -8,6 +8,7 @@ use LogicException;
 use InvalidArgumentException;
 
 use PHPCR\CredentialsInterface;
+use PHPCR\RepositoryInterface;
 use PHPCR\SimpleCredentials;
 use PHPCR\PropertyType;
 use PHPCR\SessionInterface;
@@ -402,6 +403,9 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
                     $this->descriptors[$name] = $values;
                 }
             }
+
+            // Supported by Jackrabbit, but not supported by this client
+            $this->descriptors[RepositoryInterface::NODE_TYPE_MANAGEMENT_SAME_NAME_SIBLINGS_SUPPORTED] = false;
 
             if (! isset($this->descriptors['jcr.repository.version'])) {
                 throw new UnsupportedRepositoryOperationException("The backend at {$this->server} does not provide the jcr.repository.version descriptor");


### PR DESCRIPTION
Related to [this PR in phpcr-api-tests](https://github.com/phpcr/phpcr-api-tests/pull/94): the transport reports that it supports same name siblings (SNS), getting this from the Jackrabbit server, however it's not yet supported in this client implementation.
