### PR TITLE
PROPOSAL: optimize getNodes to not fetch the same nodes twice

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -495,6 +495,24 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
                 return array();
             }
         }
+
+        // if we have a fetchDepth, optimize by removing duplicated requests
+        // for paths that will be fetched through the depth
+        if ($this->getFetchDepth()) {
+            $sorted = $paths;
+            asort($sorted);
+            $prev = ':'; // init with something that never matches
+            foreach($sorted as $key => $path) {
+                if (strpos($path, $prev . '/')
+                    && $this->getFetchDepth() >= substr_count($path, '/', strlen($prev))
+                ) {
+                    unset($paths[$key]);
+                } else {
+                    $prev = $path;
+                }
+            }
+        }
+
         $body = array();
 
         $url = $this->encodeAndValidatePathForDavex("/").'.'.$this->getFetchDepth().'.json';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | ->travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

i am not sure if this actually is a good idea. if do getNodes(array('/a', '/a/b', '/a/b/c')) with a depth of 2, we fetched /a/b twice and /a/b/c three times (once in /a, once in /a/b and once directly). with a larger depth and large nodes, this becomes expensive.

on the other hand, if we would fetch /a/b/c we would also fetch 2 levels more underneath it, which in turn could save us a lot of subsequent calls. simply increasing the depth is also not an option, there might be lots of children und /a/x/y that we do not want to fetch.

inputs?
