### PR TITLE
fix parameter validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "php": ">=5.3.3",
         "ext-xml":"*",
         "ext-curl":"*",
-        "phpcr/phpcr": "~2.1.0",
+        "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "~1.1",
-        "jackalope/jackalope": "~1.1.0"
+        "jackalope/jackalope": "~1.2.0"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"

--- a/src/Jackalope/RepositoryFactoryJackrabbit.php
+++ b/src/Jackalope/RepositoryFactoryJackrabbit.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope;
 
+use PHPCR\ConfigurationException;
 use PHPCR\RepositoryFactoryInterface;
 
 /**
@@ -58,17 +59,16 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
     public function getRepository(array $parameters = null)
     {
         if (null === $parameters) {
-            return null;
+            throw new ConfigurationException('Jackalope-jackrabbit needs parameters');
         }
 
-        // check if we have all required keys
-        $present = array_intersect_key(self::$required, $parameters);
-        if (count(array_diff_key(self::$required, $present))) {
-            return null;
+        // check if we have all required parameters
+        if (count(array_diff_key(self::$required, $parameters))) {
+            throw new ConfigurationException('A required parameter is missing: ' . implode(', ', array_keys(array_diff_key(self::$required, $parameters))));
         }
-        $defined = array_intersect_key(array_merge(self::$required, self::$optional), $parameters);
-        if (count(array_diff_key($defined, $parameters))) {
-            return null;
+        // check if we have any unknown parameters
+        if (count(array_diff_key($parameters, self::$required, self::$optional))) {
+            throw new ConfigurationException('Additional unknown parameters found: ' . implode(', ', array_keys(array_diff_key($parameters, self::$required, self::$optional))));
         }
 
         if (isset($parameters['jackalope.factory'])) {

--- a/tests/Jackalope/RepositoryFactoryJackrabbitTest.php
+++ b/tests/Jackalope/RepositoryFactoryJackrabbitTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Jackalope;
+
+class RepositoryFactoryJackrabbitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \PHPCR\ConfigurationException
+     * @expectedExceptionMessage missing
+     */
+    public function testMissingRequired()
+    {
+        $factory = new RepositoryFactoryJackrabbit();
+
+        $factory->getRepository(array());
+    }
+
+    /**
+     * @expectedException \PHPCR\ConfigurationException
+     * @expectedExceptionMessage unknown
+     */
+    public function testExtraParameter()
+    {
+        $factory = new RepositoryFactoryJackrabbit();
+
+        $factory->getRepository(array(
+            'jackalope.jackrabbit_uri' => 'http://localhost',
+            'unknown' => 'garbage',
+        ));
+    }
+}


### PR DESCRIPTION
we got the parameter validation code wrong. this PR fixes the validation and adds some tests for the error conditions.

there is a slight BC break here, in that we previously ignored unknown parameters and now detect them.

what is really user unfriendly is that the PHPCR spec says to return null if the parameters are not known. an exception would be a lot more helpful. i am tempted to violate the api doc and throw an exception.

fixes https://github.com/jackalope/jackalope/issues/243 and fixed #73
