### PR TITLE
Always overwrite as we manually check before sending the request.

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -1106,7 +1106,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
         }
 
         $body = urlencode(':clone') . '='
-            . urlencode($srcWorkspace . ',' . $srcAbsPath . ',' . $destAbsPath . ',' . ($removeExisting ? 'true' : 'false'));
+            . urlencode($srcWorkspace . ',' . $srcAbsPath . ',' . $destAbsPath . ',' . 'true');
 
         $request = $this->getRequest(Request::POST, $this->workspaceUri);
         $request->setBody($body);


### PR DESCRIPTION
Passing removeExisting false to Jackrabbit seems to result always in an
ItemExists exception, even when the item does not exist.

I wonder if this is the reason for the manual check before we send the request?
