### PR TITLE
Default the string property jcr:lastModifiedBy to current user ID rather than date

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -1275,7 +1275,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
             && !$node->getProperty('jcr:lastModifiedBy')->isModified()
             && !$node->getProperty('jcr:lastModifiedBy')->isNew()
         ) {
-            $node->setProperty('jcr:lastModifiedBy', "");
+            $node->setProperty('jcr:lastModifiedBy', $this->credentials->getUserID());
         }
     }
 


### PR DESCRIPTION
Default the string property jcr:lastModifiedBy to empty string rather than DateTime (which makes no sense)
