### PR TITLE
add charset=utf-8 for getNodes() curl call

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -505,7 +505,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
 
         $request = $this->getRequest(Request::POST, $url);
         $request->setBody($body);
-        $request->setContentType('application/x-www-form-urlencoded');
+        $request->setContentType('application/x-www-form-urlencoded; charset=utf-8');
 
         try {
             $data = $request->executeJson();


### PR DESCRIPTION
This let's getNodes() work for paths that contain multi-byte characters. I have no idea what the ramifications of this change are and whether there's a better way to do it, etc.
