### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "jackalope/jackalope": "~1.1.0"
     },
     "conflict": {
-	    "lib-curl": "7.35"
+	"lib-curl": "7.35"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"


### PR DESCRIPTION
restrict the use of lib-curl 7.35 in order to avoid "Problem (2) in the Chunked-Encoded data" described here: https://github.com/jackalope/jackalope-jackrabbit/issues/89

fix #89
