### PR TITLE
revert #89 as that version of curl does work on some systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This code is dual licensed under the MIT license and the Apache License Version
 
 * php >= 5.3
 * libxml version >= 2.7.0 (due to a bug in libxml [http://bugs.php.net/bug.php?id=36501](http://bugs.php.net/bug.php?id=36501))
+* libcurl (if you get ``Problem (2) in the Chunked-Encoded data`` with version 7.35, try updating your curl version)
 * phpunit >= 3.6 (if you want to run the tests)
 * [composer](http://getcomposer.org/)
 

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
         "phpcr/phpcr-utils": "~1.1",
         "jackalope/jackalope": "~1.1.0"
     },
-    "conflict": {
-	"lib-curl": "7.35"
-    },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"
     },


### PR DESCRIPTION
i propose we revert this change by @eXsio - jackalope-jackrabbit works fine on my ubuntu 14.04 with `lib-curl[7.35.0]`. but composer is refusing to install...

instead, we should find somewhere in the doc (faq?) where we can mention the error and say upgrading curl might fix it.

revert #95
