### PR TITLE
make sure double type is not lost when storing

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -1245,7 +1245,14 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
                 $this->setJsopBody('^' . $path . ' : ');
             }
         } else {
-            $this->setJsopBody('^' . $path . ' : ' . json_encode($value));
+            $encoded = json_encode($value);
+
+            if (PropertyType::DOUBLE == $property->getType()
+                && !strpos($encoded, '.')
+            ) {
+                $encoded .= '.0';
+            }
+            $this->setJsopBody('^' . $path . ' : ' . $encoded);
         }
     }
 


### PR DESCRIPTION
fix #92

it seems that we do not send types with diff lines - we need to make sure that float that happen to be a full number still have a .0.