### PR TITLE
[WIP] Acl support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "ext-xml":"*",
         "ext-curl":"*",
-        "phpcr/phpcr": "dev-acl",
+        "phpcr/phpcr": "dev-acl as 2.1.0",
         "phpcr/phpcr-utils": "~1.1",
         "jackalope/jackalope": "dev-acl"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "ext-curl":"*",
         "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "~1.1",
-        "jackalope/jackalope": "~1.2.0"
+        "jackalope/jackalope": "dev-acl"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"
     },
     "require-dev": {
         "psr/log": "~1.0",
-        "phpcr/phpcr-api-tests": "~2.1.0",
+        "phpcr/phpcr-api-tests": "dev-acl",
         "symfony/console": "~2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "ext-xml":"*",
         "ext-curl":"*",
-        "phpcr/phpcr": "~2.1.2",
+        "phpcr/phpcr": "dev-acl",
         "phpcr/phpcr-utils": "~1.1",
         "jackalope/jackalope": "dev-acl"
     },

--- a/prop.xml
+++ b/prop.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<D:multistatus xmlns:D="DAV:">
+    <D:response>
+        <D:href>http://localhost:8080/server/testsWorkspace/jcr%3aroot/</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:supported-privilege-set>
+                    <D:supported-privilege>
+                        <D:privilege>
+                            <jcr:all xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                        </D:privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:workspaceManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:lifecycleManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:versionManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:lockManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:read xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:modifyAccessControl xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <rep:write xmlns:rep="internal"/>
+                            </D:privilege>
+                            <D:supported-privilege>
+                                <D:privilege>
+                                    <jcr:nodeTypeManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                                </D:privilege>
+                            </D:supported-privilege>
+                            <D:supported-privilege>
+                                <D:privilege>
+                                    <jcr:write xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                                </D:privilege>
+                                <D:supported-privilege>
+                                    <D:privilege>
+                                        <jcr:removeNode xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                                    </D:privilege>
+                                </D:supported-privilege>
+                                <D:supported-privilege>
+                                    <D:privilege>
+                                        <jcr:addChildNodes xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                                    </D:privilege>
+                                </D:supported-privilege>
+                                <D:supported-privilege>
+                                    <D:privilege>
+                                        <jcr:modifyProperties xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                                    </D:privilege>
+                                </D:supported-privilege>
+                                <D:supported-privilege>
+                                    <D:privilege>
+                                        <jcr:removeChildNodes xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                                    </D:privilege>
+                                </D:supported-privilege>
+                            </D:supported-privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <rep:privilegeManagement xmlns:rep="internal"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:namespaceManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:nodeTypeDefinitionManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:retentionManagement xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                        <D:supported-privilege>
+                            <D:privilege>
+                                <jcr:readAccessControl xmlns:jcr="http://www.jcp.org/jcr/1.0"/>
+                            </D:privilege>
+                        </D:supported-privilege>
+                    </D:supported-privilege>
+                </D:supported-privilege-set>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+</D:multistatus>

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -2206,7 +2206,7 @@ class Client
            "jcr:primaryType" : "rep:ACL"';
 
         $id = 0;
-
+newline fuckup?
         foreach ($operation->policy->getAccessControlEntries() as $entry) {
             $value .= ",\n" .
                 '"entry' . $id++ . '" : {
@@ -2220,7 +2220,7 @@ class Client
 ';
 //var_dump($value);die;
 
-        $this->setJsopBody("\n+".$value, '');
+        $this->setJsopBody("+".$value, '');
     }
 
     private function buildPrivilegeList(AccessControlEntryInterface $entry)

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -2203,16 +2203,16 @@ class Client
         }
 
         $value = $operation->srcPath . '/rep:policy : {
-           jcr:primaryType : "rep:ACL"';
+           "jcr:primaryType" : "rep:ACL"';
 
         $id = 0;
 
         foreach ($operation->policy->getAccessControlEntries() as $entry) {
             $value .= ",\n" .
-                'entry' . $id++ . ' : {
-                    jcr:primaryType : "rep:grantACE",
-                    rep:principalName : "' . $entry->getPrincipal()->getName() . '",
-                    rep:privileges : [' . $this->buildPrivilegeList($entry) . ']
+                '"entry' . $id++ . '" : {
+                    "jcr:primaryType" : "rep:GrantACE",
+                    "rep:principalName" : "' . $entry->getPrincipal()->getName() . '",
+                    "rep:privileges" : [' . $this->buildPrivilegeList($entry) . ']
                 }';
         }
         $value .= '

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -2142,11 +2142,6 @@ class Client
         return $data;
     }
 
-    public function getPolicies($path)
-    {
-        return $this->getNode($path . '/rep:policy');
-    }
-
     public function getSupportedPrivileges($path = null)
     {
         $path = $this->workspaceUriRoot . $path ?: '';
@@ -2196,10 +2191,12 @@ class Client
 
     public function setPolicy(array $operation)
     {
-        foreach ($operation as $op) $this->setPolicyss($op);
+        foreach ($operation as $op) {
+            $this->setPolicyJsop($op);
+        }
     }
 
-    private function setPolicyss($operation)
+    private function setPolicyJsop($operation)
     {
         if (!$operation->policy instanceof AccessControlList) {
             throw new \Exception('wrong class');

--- a/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
+++ b/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
@@ -8,6 +8,7 @@ use Jackalope\Transport\AbstractReadWriteLoggingWrapper;
 use Jackalope\Transport\AccessControlInterface;
 use Jackalope\Transport\QueryInterface as QueryTransport;
 use Jackalope\Transport\PermissionInterface;
+use Jackalope\Transport\SetPolicyOperation;
 use Jackalope\Transport\VersioningInterface;
 use Jackalope\Transport\NodeTypeCndManagementInterface;
 use Jackalope\Transport\LockingInterface;
@@ -255,4 +256,10 @@ class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTran
     {
         return $this->transport->getSupportedPrivileges($path);
     }
+
+    public function setPolicy(SetPolicyOperation $operation)
+    {
+        $this->transport->setPolicy($operation);
+    }
+
 }

--- a/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
+++ b/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
@@ -246,12 +246,6 @@ class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTran
         $this->transport->deleteWorkspace($name);
     }
 
-
-    public function getPolicies($path)
-    {
-        return $this->transport->getPolicies($path);
-    }
-
     public function getSupportedPrivileges($path = null)
     {
         return $this->transport->getSupportedPrivileges($path);

--- a/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
+++ b/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
@@ -5,6 +5,7 @@ namespace Jackalope\Transport\Jackrabbit;
 use Jackalope\FactoryInterface;
 use Jackalope\Transport\AbstractReadWriteLoggingWrapper;
 
+use Jackalope\Transport\AccessControlInterface;
 use Jackalope\Transport\QueryInterface as QueryTransport;
 use Jackalope\Transport\PermissionInterface;
 use Jackalope\Transport\VersioningInterface;
@@ -27,7 +28,7 @@ use Jackalope\Transport\Logging\LoggerInterface;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTransport, PermissionInterface, VersioningInterface, NodeTypeCndManagementInterface, LockingInterface, ObservationInterface, WorkspaceManagementInterface
+class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTransport, PermissionInterface, VersioningInterface, NodeTypeCndManagementInterface, LockingInterface, ObservationInterface, WorkspaceManagementInterface, AccessControlInterface
 {
     /**
      * @var Client
@@ -242,5 +243,16 @@ class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTran
     public function deleteWorkspace($name)
     {
         $this->transport->deleteWorkspace($name);
+    }
+
+
+    public function getPolicies($path)
+    {
+        return $this->transport->getPolicies($path);
+    }
+
+    public function getSupportedPrivileges($path = null)
+    {
+        return $this->transport->getSupportedPrivileges($path);
     }
 }

--- a/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
+++ b/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
@@ -257,7 +257,11 @@ class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTran
         return $this->transport->getSupportedPrivileges($path);
     }
 
-    public function setPolicy(SetPolicyOperation $operation)
+    /**
+     * @param SetPolicyOperation[] $operation
+     * @throws \Exception
+     */
+    public function setPolicy(array $operation)
     {
         $this->transport->setPolicy($operation);
     }

--- a/tests/inc/ImplementationLoader.php
+++ b/tests/inc/ImplementationLoader.php
@@ -42,7 +42,6 @@ class ImplementationLoader extends \PHPCR\Test\AbstractLoader
         $this->unsupportedChapters = array(
             'PermissionsAndCapabilities',
             'ShareableNodes',
-            'AccessControlManagement',
             'LifecycleManagement',
             'RetentionAndHold',
             'Transactions',


### PR DESCRIPTION
needs the following to be added to the `<workspace>` tag in the repository.xml:

```
        <Import>
          <ProtectedNodeImporter
class="org.apache.jackrabbit.core.xml.AccessControlImporter"/>
          <ProtectedPropertyImporter
class="org.apache.jackrabbit.core.security.user.UserImporter">
             <param name="importBehavior" value="besteffort"/>
          </ProtectedPropertyImporter>
        </Import>
```

requires https://github.com/jackalope/jackalope/pull/274 and https://github.com/phpcr/phpcr-api-tests/pull/152

TODO
- [] Figure out getSupportedPrivileges vs privilegeFromName. flat list of privileges or only jcr:all with nested?
