### PR TITLE
Added force_http_version_10 option

### DIFF
--- a/src/Jackalope/RepositoryFactoryJackrabbit.php
+++ b/src/Jackalope/RepositoryFactoryJackrabbit.php
@@ -42,6 +42,7 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         'jackalope.disable_stream_wrapper' => 'boolean: if set and not empty, stream wrapper is disabled, otherwise the stream wrapper is enabled and streams are only fetched when reading from for the first time. If your code always uses all binary properties it reads, you can disable this for a small performance gain.',
         'jackalope.logger' => 'Psr\Log\LoggerInterface: Use the LoggingClient to wrap the default transport Client',
         Session::OPTION_AUTO_LASTMODIFIED => 'boolean: Whether to automatically update nodes having mix:lastModified. Defaults to true.',
+        'jackalope.jackrabbit_force_http_version_10' => 'boolean: Force HTTP version 1.0, this can in solving problems with curl such as https://github.com/jackalope/jackalope-jackrabbit/issues/89',
     );
 
     /**
@@ -92,6 +93,9 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         }
         if (isset($parameters['jackalope.check_login_on_server'])) {
             $transport->setCheckLoginOnServer($parameters['jackalope.check_login_on_server']);
+        }
+        if (isset($parameters['jackalope.jackrabbit_force_http_version_10'])) {
+            $transport->forceHttpVersion10($parameters['jackalope.jackrabbit_force_http_version_10']);
         }
         if (isset($parameters['jackalope.logger'])) {
             $transport = $factory->get('Transport\Jackrabbit\LoggingClient', array($transport, $parameters['jackalope.logger']));

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -166,17 +166,20 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     protected $curl = null;
 
     /**
-     *  A list of additional HTTP headers to be sent on each request
-     *  @var array[]string
+     * A list of additional HTTP headers to be sent on each request
+     * @var array[]string
      */
-
     protected $defaultHeaders = array();
 
     /**
-     *  @var bool Send Expect: 100-continue header
+     * @var bool Send Expect: 100-continue header
      */
-
     protected $sendExpect = false;
+
+    /**
+     * @var bool
+     */
+    protected $forceHttpVersion10 = false;
 
     /**
      * @var \Jackalope\NodeType\NodeTypeXmlConverter
@@ -266,6 +269,16 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
+     * Set to true to force HTTP version 1.0
+     *
+     * @param boolean
+     */
+    public function forceHttpVersion10($forceHttpVersion10 = true)
+    {
+        $this->forceHttpVersion10 = $forceHttpVersion10;
+    }
+
+    /**
      * Makes sure there is an open curl connection.
      *
      * @return Request The Request
@@ -293,6 +306,10 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
 
         if (!$this->sendExpect) {
             $request->addHeader("Expect:");
+        }
+
+        if ($this->forceHttpVersion10) {
+            $request->forceHttpVersion10();
         }
 
         return $request;


### PR DESCRIPTION
This PR forces the HTTP version 1.0 mode on the curl library.

We encountered the same issue reported in #89 but changing the curl version has not helped.

/cc @chirimoya 