### PR TITLE
move special value conversion check to jackalope-jackrabbit

### DIFF
--- a/src/Jackalope/Jackrabbit/Factory.php
+++ b/src/Jackalope/Jackrabbit/Factory.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Jackalope\Jackrabbit;
+use Jackalope\Jackrabbit\Util\ValueConverter;
 
 /**
  * Jackalope implementation factory.
@@ -19,6 +20,8 @@ class Factory extends \Jackalope\Factory
             case 'Query\QOM\QueryObjectModelFactory':
                 $name = 'Jackrabbit\Query\QOM\QueryObjectModelFactory';
                 break;
+            case 'PHPCR\Util\ValueConverter':
+                return new ValueConverter();
         }
 
         return parent::get($name,$params);

--- a/src/Jackalope/Jackrabbit/Util/ValueConverter.php
+++ b/src/Jackalope/Jackrabbit/Util/ValueConverter.php
@@ -1,0 +1,38 @@
+<?php
+namespace Jackalope\Jackrabbit\Util;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+use PHPCR\Util\ValueConverter as BaseValueConverter;
+use PHPCR\ValueFormatException;
+
+class ValueConverter extends BaseValueConverter
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Overwritten to validate that unpersisted nodes are not referenced.
+     *
+     * This is needed because of this jackrabbit issue:
+     * https://issues.apache.org/jira/browse/JCR-1614
+     */
+    public function convertType($value, $type, $srctype = PropertyType::UNDEFINED)
+    {
+        if (is_array($value)) {
+            return parent::convertType($value, $type, $srctype);
+        }
+        if (PropertyType::UNDEFINED == $srctype) {
+            $srctype = $this->determineType($value);
+        }
+
+        if ((PropertyType::REFERENCE == $srctype || PropertyType::WEAKREFERENCE == $srctype)
+            && $value instanceof NodeInterface
+        ) {
+            if ($value->isNew()) {
+                throw new ValueFormatException('Node ' . $value->getPath() . ' must be persisted before being referenceable');
+            }
+        }
+
+        return parent::convertType($value, $type, $srctype);
+    }
+}


### PR DESCRIPTION
prepare jackalope-jackrabbit to cope with https://github.com/phpcr/phpcr-utils/pull/152

its no problem to run this code with an older version of phpcr-utils, but if jackalope-jackrabbit runs without this change but https://github.com/phpcr/phpcr-utils/pull/152 merged, the validation will not happen. i guess as its only validation, we can live with it.