### PR TITLE
version restore: update jackalope and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "ext-curl":"*",
         "phpcr/phpcr": "~2.1.2",
         "phpcr/phpcr-utils": "~1.2,>=1.2.6",
-        "jackalope/jackalope": "~1.2.2"
+        "jackalope/jackalope": "~1.2.3"
     },
     "provide": {
         "jackalope/jackalope-transport": "1.1.0"
     },
     "require-dev": {
         "psr/log": "~1.0",
-        "phpcr/phpcr-api-tests": "2.1.7",
+        "phpcr/phpcr-api-tests": "2.1.8",
         "symfony/console": "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
test https://github.com/jackalope/jackalope/pull/294 with https://github.com/phpcr/phpcr-api-tests/pull/166

i am not sure if we want to tag jackalope/jackalope and the tests immediately or try to wrap up the other fixes and tag somewhen end of this week.