### PR TITLE
Added function to set global curl-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3
+---
+
+* Added function to set global curl-options
+
 1.2
 ---
 

--- a/src/Jackalope/RepositoryFactoryJackrabbit.php
+++ b/src/Jackalope/RepositoryFactoryJackrabbit.php
@@ -44,6 +44,7 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         'jackalope.logger' => 'Psr\Log\LoggerInterface: Use the LoggingClient to wrap the default transport Client',
         Session::OPTION_AUTO_LASTMODIFIED => 'boolean: Whether to automatically update nodes having mix:lastModified. Defaults to true.',
         'jackalope.jackrabbit_force_http_version_10' => 'boolean: Force HTTP version 1.0, this can in solving problems with curl such as https://github.com/jackalope/jackalope-jackrabbit/issues/89',
+        'jackalope.jackrabbit_curl_options' => 'array: Additional global curl-options',
     );
 
     /**
@@ -67,6 +68,7 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         if (count(array_diff_key(self::$required, $parameters))) {
             throw new ConfigurationException('A required parameter is missing: ' . implode(', ', array_keys(array_diff_key(self::$required, $parameters))));
         }
+
         // check if we have any unknown parameters
         if (count(array_diff_key($parameters, self::$required, self::$optional))) {
             throw new ConfigurationException('Additional unknown parameters found: ' . implode(', ', array_keys(array_diff_key($parameters, self::$required, self::$optional))));
@@ -94,11 +96,22 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         if (isset($parameters['jackalope.check_login_on_server'])) {
             $transport->setCheckLoginOnServer($parameters['jackalope.check_login_on_server']);
         }
-        if (isset($parameters['jackalope.jackrabbit_force_http_version_10'])) {
-            $transport->forceHttpVersion10($parameters['jackalope.jackrabbit_force_http_version_10']);
-        }
         if (isset($parameters['jackalope.logger'])) {
-            $transport = $factory->get('Transport\Jackrabbit\LoggingClient', array($transport, $parameters['jackalope.logger']));
+            $transport = $factory->get(
+                'Transport\Jackrabbit\LoggingClient',
+                array($transport, $parameters['jackalope.logger'])
+            );
+        }
+
+        $curlOptions = array_key_exists('jackalope.jackrabbit_curl_options', $parameters) ?
+            $parameters['jackalope.jackrabbit_curl_options'] : array();
+
+        if (isset($parameters['jackalope.jackrabbit_force_http_version_10'])) {
+            $curlOptions[CURLOPT_HTTP_VERSION] = true;
+        }
+
+        if (count($curlOptions)) {
+            $transport->addCurlOptions($curlOptions);
         }
 
         $options['stream_wrapper'] = empty($parameters['jackalope.disable_stream_wrapper']);

--- a/src/Jackalope/Transport/Jackrabbit/Request.php
+++ b/src/Jackalope/Transport/Jackrabbit/Request.php
@@ -217,10 +217,11 @@ class Request
     protected $errorHandlingMode = false;
 
     /**
-     * Force curl to use HTTP version 1.0
-     * @var bool
+     * Global curl-options used in this request.
+     *
+     * @var array
      */
-    protected $forceHttpVersion10 = false;
+    private $curlOptions = array();
 
     /**
      * Initiaties the NodeTypes request object.
@@ -242,10 +243,22 @@ class Request
 
     /**
      * Force curl to use HTTP version 1.0
+     *
+     * @deprecated use addCurlOptions([CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0]) instead
      */
     public function forceHttpVersion10()
     {
-        $this->forceHttpVersion10 = true;
+        $this->addCurlOptions(array(CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0));
+    }
+
+    /**
+     * Add curl-options for this request.
+     *
+     * @param array $options
+     */
+    public function addCurlOptions(array $options)
+    {
+        $this->curlOptions += $options;
     }
 
     /**
@@ -364,6 +377,10 @@ class Request
             $headers[] = 'Lock-Token: <'.$this->lockToken.'>';
         }
 
+        foreach ($this->curlOptions as $option => $optionValue) {
+            $curl->setopt($option, $optionValue);
+        }
+
         $curl->setopt(CURLOPT_RETURNTRANSFER, true);
         $curl->setopt(CURLOPT_CUSTOMREQUEST, $this->method);
 
@@ -477,17 +494,16 @@ class Request
             $headers[] = 'Lock-Token: <'.$this->lockToken.'>';
         }
 
+        foreach ($this->curlOptions as $option => $optionValue) {
+            $curl->setopt($option, $optionValue);
+        }
+
         $curl->setopt(CURLOPT_RETURNTRANSFER, true);
         $curl->setopt(CURLOPT_CUSTOMREQUEST, $this->method);
         $curl->setopt(CURLOPT_URL, reset($this->uri));
         $curl->setopt(CURLOPT_HTTPHEADER, $headers);
         $curl->setopt(CURLOPT_POSTFIELDS, $this->body);
 
-        if (true === $this->forceHttpVersion10) {
-            $curl->setopt(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
-        }
-        // uncomment next line to get verbose information from CURL
-        //$curl->setopt(CURLOPT_VERBOSE, 1);
         if ($getCurlObject) {
             $curl->parseResponseHeaders();
         }


### PR DESCRIPTION
Added possibility to set global curl-options. Sulu has some problems with the curl-connection cache. At some points jackrabbit seems to crash when reusing a connection. I have added the CURLOPT_FORBID_REUSE option to curl-handler and it seems to work. according to @dantleech we decided to add a function which allows to add curl-options to the client (which would replace the force-http-version).

Link to a failing testcase: https://travis-ci.org/sulu-io/sulu/jobs/107715661#L952