### PR TITLE
Extracted interface for jackrabbit client

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -66,7 +66,7 @@ use PHPCR\Version\LabelExistsVersionException;
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  * @author Markus Schmucker <markus.sr@gmx.net>
  */
-class Client extends BaseTransport implements QueryTransport, PermissionInterface, WritingInterface, VersioningInterface, NodeTypeCndManagementInterface, LockingInterface, ObservationInterface, WorkspaceManagementInterface
+class Client extends BaseTransport implements JackrabbitClientInterface
 {
     /**
      * minimal version needed for the backend server
@@ -242,15 +242,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * Add a HTTP header which is sent on each Request.
-     *
-     * This is used for example for a session identifier header to help a proxy
-     * to route all requests from the same session to the same server.
-     *
-     * This is a Jackrabbit Davex specific option called from the repository
-     * factory.
-     *
-     * @param string $header a valid HTTP header to add to each request
+     * {@inheritDoc}
      */
     public function addDefaultHeader($header)
     {
@@ -258,12 +250,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * If you want to send the "Expect: 100-continue" header on larger
-     * PUT and POST requests, set this to true.
-     *
-     * This is a Jackrabbit Davex specific option.
-     *
-     * @param bool $send Whether to send the header or not
+     * {@inheritDoc}
      */
     public function sendExpect($send = true)
     {
@@ -271,11 +258,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * Set to true to force HTTP version 1.0
-     *
-     * @param boolean
-     *
-     * @deprecated use addCurlOptions([CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0]) instead
+     * {@inheritDoc}
      */
     public function forceHttpVersion10($forceHttpVersion10 = true)
     {
@@ -287,13 +270,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * Add global curl-options.
-     *
-     * This options will be used foreach curl-request.
-     *
-     * @param array $options
-     *
-     * @return array all curl-options
+     * {@inheritDoc}
      */
     public function addCurlOptions(array $options)
     {
@@ -349,9 +326,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * Return the URL to the workspace determined during login
-     *
-     * @return null|string
+     * {@inheritDoc}
      */
     public function getWorkspaceUri()
     {
@@ -424,9 +399,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * Configure whether to check if we are logged in before doing a request.
-     *
-     * Will improve error reporting at the cost of some round trips.
+     * {@inheritDoc}
      */
     public function setCheckLoginOnServer($bool)
     {
@@ -781,7 +754,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     // VersioningInterface //
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function addVersionLabel($versionPath, $label, $moveLabel)
     {
@@ -810,7 +783,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function removeVersionLabel($versionPath, $label)
     {
@@ -1170,6 +1143,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
             $this->setJsopBody(">" . $operation->srcPath . " : " . $operation->dstPath);
         }
     }
+
     /**
      * {@inheritDoc}
      */
@@ -1499,9 +1473,6 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
 
     /**
      * {@inheritDoc}
-     *
-     * @throws UnsupportedRepositoryOperationException if trying to
-     *      overwrite existing prefix to new uri, as jackrabbit can not do this
      */
     public function registerNamespace($prefix, $uri)
     {
@@ -1693,15 +1664,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * Internal method to fetch event data.
-     *
-     * @param $date
-     *
-     * @return array hashmap with 'data' containing unfiltered DOM of xml atom
-     *      feed of events, 'nextMillis' is the next timestamp if there are
-     *      more events to be found, false otherwise.
-     *
-     * @private
+     * {@inheritDoc}
      */
     public function fetchEventData($date)
     {
@@ -1735,7 +1698,7 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
     }
 
     /**
-     * @return mixed null or string
+     * {@inheritDoc}
      */
     public function getUserData()
     {
@@ -1768,6 +1731,9 @@ class Client extends BaseTransport implements QueryTransport, PermissionInterfac
         $request->execute();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function deleteWorkspace($name)
     {
         // https://issues.apache.org/jira/browse/JCR-3144

--- a/src/Jackalope/Transport/Jackrabbit/JackrabbitClientInterface.php
+++ b/src/Jackalope/Transport/Jackrabbit/JackrabbitClientInterface.php
@@ -12,7 +12,9 @@ use Jackalope\Transport\WorkspaceManagementInterface;
 use Jackalope\Transport\WritingInterface;
 
 /**
- * Internal interface for jackrabbit client.
+ * Collect all interfaces the jackrabbit client implements and define the additional jackrabbit specific methods.
+ *
+ * @internal
  */
 interface JackrabbitClientInterface extends QueryTransport, PermissionInterface, WritingInterface, VersioningInterface, NodeTypeCndManagementInterface, LockingInterface, ObservationInterface, WorkspaceManagementInterface
 {

--- a/src/Jackalope/Transport/Jackrabbit/JackrabbitClientInterface.php
+++ b/src/Jackalope/Transport/Jackrabbit/JackrabbitClientInterface.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jackalope\Transport\Jackrabbit;
+
+use Jackalope\Transport\LockingInterface;
+use Jackalope\Transport\NodeTypeCndManagementInterface;
+use Jackalope\Transport\ObservationInterface;
+use Jackalope\Transport\PermissionInterface;
+use Jackalope\Transport\QueryInterface as QueryTransport;
+use Jackalope\Transport\VersioningInterface;
+use Jackalope\Transport\WorkspaceManagementInterface;
+use Jackalope\Transport\WritingInterface;
+
+/**
+ * Internal interface for jackrabbit client.
+ */
+interface JackrabbitClientInterface extends QueryTransport, PermissionInterface, WritingInterface, VersioningInterface, NodeTypeCndManagementInterface, LockingInterface, ObservationInterface, WorkspaceManagementInterface
+{
+    /**
+     * Add a HTTP header which is sent on each Request.
+     *
+     * This is used for example for a session identifier header to help a proxy
+     * to route all requests from the same session to the same server.
+     *
+     * This is a Jackrabbit Davex specific option called from the repository
+     * factory.
+     *
+     * @param string $header a valid HTTP header to add to each request
+     */
+    public function addDefaultHeader($header);
+
+    /**
+     * If you want to send the "Expect: 100-continue" header on larger
+     * PUT and POST requests, set this to true.
+     *
+     * This is a Jackrabbit Davex specific option.
+     *
+     * @param bool $send Whether to send the header or not
+     */
+    public function sendExpect($send = true);
+
+    /**
+     * Set to true to force HTTP version 1.0
+     *
+     * @param boolean
+     *
+     * @deprecated use addCurlOptions([CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0]) instead
+     */
+    public function forceHttpVersion10($forceHttpVersion10 = true);
+
+    /**
+     * Add global curl-options.
+     *
+     * This options will be used foreach curl-request.
+     *
+     * @param array $options
+     *
+     * @return array all curl-options
+     */
+    public function addCurlOptions(array $options);
+
+    /**
+     * Return the URL to the workspace determined during login
+     *
+     * @return null|string
+     */
+    public function getWorkspaceUri();
+
+    /**
+     * Configure whether to check if we are logged in before doing a request.
+     *
+     * Will improve error reporting at the cost of some round trips.
+     */
+    public function setCheckLoginOnServer($bool);
+
+    /**
+     * Internal method to fetch event data.
+     *
+     * @param $date
+     *
+     * @return array hashmap with 'data' containing unfiltered DOM of xml atom
+     *      feed of events, 'nextMillis' is the next timestamp if there are
+     *      more events to be found, false otherwise.
+     *
+     * @private
+     */
+    public function fetchEventData($date);
+
+    /**
+     * @return mixed null or string
+     */
+    public function getUserData();
+}

--- a/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
+++ b/src/Jackalope/Transport/Jackrabbit/LoggingClient.php
@@ -24,7 +24,7 @@ use Jackalope\Transport\Logging\LoggerInterface;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTransport, PermissionInterface, VersioningInterface, NodeTypeCndManagementInterface, LockingInterface, ObservationInterface, WorkspaceManagementInterface
+class LoggingClient extends AbstractReadWriteLoggingWrapper implements JackrabbitClientInterface
 {
     /**
      * @var Client
@@ -255,5 +255,29 @@ class LoggingClient extends AbstractReadWriteLoggingWrapper implements QueryTran
     public function deleteWorkspace($name)
     {
         $this->transport->deleteWorkspace($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function forceHttpVersion10($forceHttpVersion10 = true)
+    {
+        $this->transport->forceHttpVersion10($forceHttpVersion10);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addCurlOptions(array $options)
+    {
+        return $this->transport->addCurlOptions($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWorkspaceUri()
+    {
+        return $this->transport->getWorkspaceUri();
     }
 }


### PR DESCRIPTION
This PR ensures that the `LoggingClient` implements the same interface as the real `Client`.

The problem is: When you use activate logging and set additional curl-options. this leads into a `UndefinedMethodException`.

To ensure that also in the future I have introduced an Interface which extends the PHPCR interfaces with the jackrabbit specific methods. This Interface will be implemented by the `Client` and the `LoggingClient`.