### PR TITLE
autoload files in phpcr tests folder when running tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
         "psr-0": { "Jackalope\\": "src/" }
     },
     "autoload-dev": {
-        "psr-0": { "Jackalope\\": "tests/" }
+        "psr-0": {
+            "Jackalope\\": "tests/",
+            "PHPCR": "vendor/phpcr/phpcr/tests"
+        }
     },
     "bin": ["bin/jackalope", "bin/jackrabbit.sh"],
     "extra": {


### PR DESCRIPTION
the phpcr tests rely on a mock interface to exist which is located in their test folder.
we run the phpcr tests when running the tests of this repository, so we need to load the classes.