### PR TITLE
Allow valid XML characters outside of BMP when storing property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.4.2
+-----
+
+* Allow to enable UTF8 support by configuring `jackalope.jackrabbit_version` parameter.
+
 1.4.1
 -----
 

--- a/src/Jackalope/RepositoryFactoryJackrabbit.php
+++ b/src/Jackalope/RepositoryFactoryJackrabbit.php
@@ -87,6 +87,7 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         if ('/' !== substr($uri, -1, 1)) {
             $uri .= '/';
         }
+
         $transport = $factory->get('Transport\Jackrabbit\Client', array($uri));
         if (isset($parameters['jackalope.default_header'])) {
             $transport->addDefaultHeader($parameters['jackalope.default_header']);

--- a/src/Jackalope/RepositoryFactoryJackrabbit.php
+++ b/src/Jackalope/RepositoryFactoryJackrabbit.php
@@ -2,6 +2,7 @@
 
 namespace Jackalope;
 
+use Jackalope\Transport\Jackrabbit\Client;
 use PHPCR\ConfigurationException;
 use PHPCR\RepositoryFactoryInterface;
 
@@ -45,6 +46,7 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         Session::OPTION_AUTO_LASTMODIFIED => 'boolean: Whether to automatically update nodes having mix:lastModified. Defaults to true.',
         'jackalope.jackrabbit_force_http_version_10' => 'boolean: Force HTTP version 1.0, this can in solving problems with curl such as https://github.com/jackalope/jackalope-jackrabbit/issues/89',
         'jackalope.jackrabbit_curl_options' => 'array: Additional global curl-options',
+        'jackalope.jackrabbit_version' => 'string: Set the version of the jackrabbit for additional support',
     );
 
     /**
@@ -85,7 +87,6 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         if ('/' !== substr($uri, -1, 1)) {
             $uri .= '/';
         }
-
         $transport = $factory->get('Transport\Jackrabbit\Client', array($uri));
         if (isset($parameters['jackalope.default_header'])) {
             $transport->addDefaultHeader($parameters['jackalope.default_header']);
@@ -95,6 +96,9 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         }
         if (isset($parameters['jackalope.check_login_on_server'])) {
             $transport->setCheckLoginOnServer($parameters['jackalope.check_login_on_server']);
+        }
+        if (isset($parameters['jackalope.jackrabbit_version'])) {
+            $transport->setVersion($parameters['jackalope.jackrabbit_version']);
         }
         if (isset($parameters['jackalope.logger'])) {
             $transport = $factory->get(

--- a/src/Jackalope/RepositoryFactoryJackrabbit.php
+++ b/src/Jackalope/RepositoryFactoryJackrabbit.php
@@ -2,7 +2,6 @@
 
 namespace Jackalope;
 
-use Jackalope\Transport\Jackrabbit\Client;
 use PHPCR\ConfigurationException;
 use PHPCR\RepositoryFactoryInterface;
 
@@ -46,7 +45,7 @@ class RepositoryFactoryJackrabbit implements RepositoryFactoryInterface
         Session::OPTION_AUTO_LASTMODIFIED => 'boolean: Whether to automatically update nodes having mix:lastModified. Defaults to true.',
         'jackalope.jackrabbit_force_http_version_10' => 'boolean: Force HTTP version 1.0, this can in solving problems with curl such as https://github.com/jackalope/jackalope-jackrabbit/issues/89',
         'jackalope.jackrabbit_curl_options' => 'array: Additional global curl-options',
-        'jackalope.jackrabbit_version' => 'string: Set the version of the jackrabbit for additional support',
+        'jackalope.jackrabbit_version' => 'string: Set the version of the jackrabbit server to allow the client to offer better functionality if possible',
     );
 
     /**

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -215,6 +215,11 @@ class Client extends BaseTransport implements JackrabbitClientInterface
     private $curlOptions = array();
 
     /**
+     * @var string|null
+     */
+    protected $version = null;
+
+    /**
      * Create a transport pointing to a server url.
      *
      * @param FactoryInterface $factory   the object factory
@@ -1326,7 +1331,12 @@ class Client extends BaseTransport implements JackrabbitClientInterface
      */
     protected function isStringValid($string)
     {
-        $regex = '/[^\x{9}\x{a}\x{d}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u';
+        $regex = '/[^\x{9}\x{a}\x{d}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}]+/u';
+
+        if ($this->version && version_compare($this->version, '2.18.0', '>=')) {
+            // unicode symbols outside of bmp such as emojis are supported only by recent jackrabbit versions
+            $regex = '/[^\x{9}\x{a}\x{d}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u';
+        }
 
         return (preg_match($regex, $string, $matches) === 0);
     }
@@ -2170,5 +2180,10 @@ class Client extends BaseTransport implements JackrabbitClientInterface
         }
 
         return $data;
+    }
+
+    public function setVersion($version)
+    {
+        $this->version = $version;
     }
 }

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -1319,14 +1319,14 @@ class Client extends BaseTransport implements JackrabbitClientInterface
      * If occurrence is found, returns false, otherwise true.
      * Invalid characters were taken from this list: http://en.wikipedia.org/wiki/Valid_characters_in_XML#XML_1.0
      *
-     * Uses regexp mentioned here: http://stackoverflow.com/a/961504
+     * Uses regexp built upon: http://stackoverflow.com/a/961504, https://stackoverflow.com/a/30240915
      *
      * @param $string string value
      * @return bool true if string is OK, false otherwise.
      */
     protected function isStringValid($string)
     {
-        $regex = '/[^\x{9}\x{a}\x{d}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}]+/u';
+        $regex = '/[^\x{9}\x{a}\x{d}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/u';
 
         return (preg_match($regex, $string, $matches) === 0);
     }

--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -215,9 +215,11 @@ class Client extends BaseTransport implements JackrabbitClientInterface
     private $curlOptions = array();
 
     /**
+     * Version of the jackrabbit server as configured.
+     *
      * @var string|null
      */
-    protected $version = null;
+    private $version = null;
 
     /**
      * Create a transport pointing to a server url.

--- a/tests/Jackalope/Transport/Jackrabbit/ClientTest.php
+++ b/tests/Jackalope/Transport/Jackrabbit/ClientTest.php
@@ -555,7 +555,7 @@ class ClientTest extends JackrabbitTestCase
     /**
      * @dataProvider provideTestOutOfRangeCharacters
      */
-    public function testOutOfRangeCharacterOccurrence($string, $isValid): void
+    public function testOutOfRangeCharacterOccurrence($string, $version, $isValid): void
     {
         if (false === $isValid) {
             $this->expectException(ValueFormatException::class);
@@ -563,6 +563,7 @@ class ClientTest extends JackrabbitTestCase
         }
 
         $t = $this->getTransportMock();
+        $t->setVersion($version);
 
         $factory = new Factory;
         $session = $this->createMock(Session::class);
@@ -596,18 +597,20 @@ class ClientTest extends JackrabbitTestCase
     {
         // use http://rishida.net/tools/conversion/ to convert problematic utf-16 strings to code points
         return array(
-            array('This is valid too!'.$this->translateCharFromCode('\u0009'), true),
-            array('This is valid', true),
-            array($this->translateCharFromCode('\uD7FF'), true),
-            array('This is on the edge, but valid too.'. $this->translateCharFromCode('\uFFFD'), true),
-            array($this->translateCharFromCode('\u10000'), true),
-            array($this->translateCharFromCode('\u10FFFF'), true),
-            array($this->translateCharFromCode('\u0001'), false),
-            array($this->translateCharFromCode('\u0002'), false),
-            array($this->translateCharFromCode('\u0003'), false),
-            array($this->translateCharFromCode('\u0008'), false),
-            array($this->translateCharFromCode('\uFFFF'), false),
-            array($this->translateCharFromCode('Sporty Spice at Sporty spice @ work \uD83D\uDCAA\uD83D\uDCAA\uD83D\uDCAA'), false),
+            array('This is valid too!'.$this->translateCharFromCode('\u0009'), null, true),
+            array('This is valid', null, true),
+            array($this->translateCharFromCode('\uD7FF'), null, true),
+            array('This is on the edge, but valid too.'. $this->translateCharFromCode('\uFFFD'), null, true),
+            array($this->translateCharFromCode('\u10000'), null, true),
+            array($this->translateCharFromCode('\u10FFFF'), null, true),
+            array($this->translateCharFromCode('\u0001'), null, false),
+            array($this->translateCharFromCode('\u0002'), null, false),
+            array($this->translateCharFromCode('\u0003'), null, false),
+            array($this->translateCharFromCode('\u0008'), null, false),
+            array($this->translateCharFromCode('\uFFFF'), null, false),
+            array($this->translateCharFromCode('Sporty Spice at Sporty spice @ work \uD83D\uDCAA\uD83D\uDCAA\uD83D\uDCAA'), null, false),
+            array($this->translateCharFromCode('Sporty Spice at Sporty spice @ work \uD83D\uDCAA\uD83D\uDCAA\uD83D\uDCAA'), '2.8.0', false),
+            array($this->translateCharFromCode('Sporty Spice at Sporty spice @ work \uD83D\uDCAA\uD83D\uDCAA\uD83D\uDCAA'), '2.18.1', true),
         );
     }
 


### PR DESCRIPTION
This PR adjusts the validation of valid XML characters in the `Client` to allow [UTF8 characters that are not in the BMP](https://mathiasbynens.be/notes/javascript-unicode#unicode-basics). At the moment, treating these characters as invalid makes it impossible to store emojis such as 🤓 or 🤯 (see https://github.com/jackalope/jackalope-jackrabbit/issues/85#issuecomment-717831267).

Per specification, the characters in the range `U+10000–U+10FFFF` are valid inside of XML documents: https://en.wikipedia.org/wiki/Valid_characters_in_XML#XML_1.0

It looks like the [stackoverflow answer that was used as a reference](https://stackoverflow.com/a/961504) when implementing the RegEx does not include this range, but the range is included in multiple other answers:
* https://stackoverflow.com/a/30240915
* https://stackoverflow.com/a/1477316
* https://stackoverflow.com/a/7726882


