### PR TITLE
Allow to use another version in jackrabbit.sh script

### DIFF
--- a/bin/jackrabbit.sh
+++ b/bin/jackrabbit.sh
@@ -3,8 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-VERSION=2.21.10
-
+VERSION="${JACKRABBIT_VERSION:-2.8.0}"
 JAR=jackrabbit-standalone-$VERSION.jar
 
 # download jackrabbit jar from archive, as the dist only contains the latest

--- a/bin/jackrabbit.sh
+++ b/bin/jackrabbit.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 
-VERSION=2.8.0
+VERSION=2.21.10
 
 JAR=jackrabbit-standalone-$VERSION.jar
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "psr/log": "~1.0",
         "phpcr/phpcr-api-tests": "2.1.22",
-        "symfony/console": "^2.3 || ^3.4 || ^4.3 || ^5.0",
+        "symfony/console": "^2.3 || ^3.4 || ^4.3 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0"
     },
     "autoload": {


### PR DESCRIPTION
The jackrabbit 2.8.0 fails strangely in the CI: https://github.com/phpcr/phpcr-shell/pull/211

When a modern version like `2.20.1` / `2.21.10` works like expected: https://github.com/phpcr/phpcr-shell/pull/212/files

Example usage:

```bash
JACKRABBIT_VERSION=2.20.1 tests/bin/travis_jackrabbit.sh
```

I first tried to use also in this CI a newer version but that seems to fail: https://github.com/jackalope/jackalope-jackrabbit/runs/6098955954?check_suite_focus=true