### PR TITLE
Fix problem with content type parsing

### DIFF
--- a/src/Jackalope/Transport/Jackrabbit/Client.php
+++ b/src/Jackalope/Transport/Jackrabbit/Client.php
@@ -663,7 +663,7 @@ class Client extends BaseTransport implements JackrabbitClientInterface
         $path = $this->encodeAndValidatePathForDavex($path);
         $request = $this->getRequest(Request::GET, $path);
         $curl = $request->execute(true);
-        switch ($curl->getHeader('Content-Type')) {
+        switch (strtolower($curl->getHeader('Content-Type'))) {
             case 'text/xml; charset=utf-8':
             case 'text/xml;charset=utf-8':
                 return $this->decodeBinaryDom($curl->getResponse());


### PR DESCRIPTION
While upgrading phpcr shell I did stumble over the following error that jackrabbit did return `UTF-8` and not `utf-8` in the response and so got the strange error:

>    Command failed: (1) [PHPCR\RepositoryException] Unknown encoding of binary data: text/xml; charset=UTF-8 (Exception)
